### PR TITLE
Spruce up quil-mode.el

### DIFF
--- a/quil-mode.el
+++ b/quil-mode.el
@@ -62,14 +62,13 @@
 (defun quil-indent-line-function ()
   (if (or (save-excursion
             ;; The previous line is a DEFGATE or DEFCIRCUIT
-            (beginning-of-line)
-            (previous-line)
+	    (forward-line -1)
             (re-search-forward (rx (or "DEFGATE" "DEFCIRCUIT")
                                    (1+ (or space ?\( ?\) ?# ?_ word)) ?:)
                                (line-end-position) t))
           (save-excursion
             ;; Previous line is indent to column four
-            (previous-line)
+            (forward-line -1)
             (beginning-of-line-text)
             (/= 0 (current-column))))
       (indent-line-to 4)))

--- a/quil-mode.el
+++ b/quil-mode.el
@@ -34,14 +34,16 @@
   `(;; Keywords
     ,(rx symbol-start
          (or "DEFGATE" "DEFCIRCUIT" "MEASURE" "RESET" "HALT" "JUMP" "JUMP-WHEN"
-             "JUMP-UNLESS" "WAIT" "DECLARE" "NEG" "NOT" "TRUE" "FALSE" "AND" "OR" "LABEL"
+             "JUMP-UNLESS" "WAIT" "NEG" "NOT" "TRUE" "FALSE" "AND" "OR" "LABEL"
              "IOR" "XOR" "ADD" "SUB" "MUL" "DIV" "MOVE" "EXCHANGE" "CONVERT" "LOAD"
              "STORE" "EQ" "GT" "GE" "LT" "LE" "NOP" "INCLUDE" "PRAGMA" "PLUS" "MINUS"
-             "CONTROLLED" "DAGGER" "DECLARE" "HALT")
+             "CONTROLLED" "DAGGER" "DECLARE" "HALT" "FORKED" "SHARING" "OFFSET"
+	     "AS" "MATRIX" "PERMUTATION")
          symbol-end)
     (,(rx symbol-start (or "SIN" "COS" "SQRT" "EXP" "CIS" (+ (? "-") "pi") (+ (? "-") "i")
                            "I" "X" "Y" "Z" "H" "CZ" "PHASE" "CPHASE" "S" "T" "CPHASE00" "CPHASE01"
-                           "CPHASE10" "RX" "RY" "RZ" "CNOT" "CCNOT" "PSWAP" "SWAP" "ISWAP" "CSWAP")
+                           "CPHASE10" "RX" "RY" "RZ" "CNOT" "CCNOT" "PSWAP" "SWAP" "ISWAP" "CSWAP"
+			   "PISWAP")
           symbol-end)
      . font-lock-builtin-face)
     (,(rx symbol-start (or "DEFGATE" "DEFCIRCUIT") (1+ space) (group (1+ (or word ?_))) (0+ (or space word ?_)))

--- a/test.quil
+++ b/test.quil
@@ -2,6 +2,13 @@ DEFGATE TESTGATE(%theta) A B:
     0, i,
     1, COS(-i*%theta)
 
+DEFGATE TESTMATRIX AS MATRIX:
+    0, 1,
+    1, 0
+
+DEFGATE TESTPERM AS PERMUTATION:
+    0, 3, 2, 1
+
 DEFCIRCUIT TESTCIRC A B:
     H A
     CNOT A B


### PR DESCRIPTION
**Updates to quil-mode keywords and builtins**

- Remove duplicate DECLARE from keywords
- Add new keywords: FORKED, SHARING, OFFSET, AS, MATRIX, PERMUTATION
- Add new built-in gate PISWAP
- Add AS MATRIX/PERMUTATION examples to `test.quil`

**Replace `(previous-line)` with `(forward-line -1)`**

The docs for previous-line claim

    This function is for interactive use only;
    in Lisp code use `forward-line' with negative argument instead.

As a side benefit, `forward-line` also moves you to the beginning of the line, rendering the explicit `beginning-of-line` redundant.

As a side-side benefit, this change satisfies my elisp linter :-).