### PR TITLE
Fix indentation of multi-line comments.

### DIFF
--- a/quil-mode.el
+++ b/quil-mode.el
@@ -63,6 +63,13 @@
     st)
   "Quil mode syntax table")
 
+(defun quil-beginning-of-line-text-or-comment-start (&optional n)
+  "Move backwards to either `beginning-of-line-text' or the `comment-start'."
+  (beginning-of-line-text n)
+  (let ((comment-start (comment-search-backward (line-beginning-position) t)))
+    (when comment-start
+      (goto-char comment-start))))
+
 (defun quil-indent-line-function ()
   (if (or (save-excursion
             ;; The previous line is a DEFGATE or DEFCIRCUIT
@@ -73,8 +80,8 @@
           (save-excursion
             ;; Previous line is indent to column four
             (forward-line -1)
-            (beginning-of-line-text)
-            (/= 0 (current-column))))
+            (quil-beginning-of-line-text-or-comment-start)
+	    (/= 0 (current-column))))
       (indent-line-to 4)))
 
 ;;;###autoload

--- a/quil-mode.el
+++ b/quil-mode.el
@@ -42,12 +42,12 @@
              "IOR" "XOR" "ADD" "SUB" "MUL" "DIV" "MOVE" "EXCHANGE" "CONVERT" "LOAD"
              "STORE" "EQ" "GT" "GE" "LT" "LE" "NOP" "INCLUDE" "PRAGMA" "PLUS" "MINUS"
              "CONTROLLED" "DAGGER" "DECLARE" "HALT" "FORKED" "SHARING" "OFFSET"
-	     "AS" "MATRIX" "PERMUTATION")
+             "AS" "MATRIX" "PERMUTATION")
          symbol-end)
     (,(rx symbol-start (or "SIN" "COS" "SQRT" "EXP" "CIS" (+ (? "-") "pi") (+ (? "-") "i")
                            "I" "X" "Y" "Z" "H" "CZ" "PHASE" "CPHASE" "S" "T" "CPHASE00" "CPHASE01"
                            "CPHASE10" "RX" "RY" "RZ" "CNOT" "CCNOT" "PSWAP" "SWAP" "ISWAP" "CSWAP"
-			   "PISWAP")
+                           "PISWAP")
           symbol-end)
      . font-lock-builtin-face)
     (,(rx symbol-start (or "DEFGATE" "DEFCIRCUIT") (1+ space) (group (1+ (or word ?_))) (0+ (or space word ?_)))
@@ -73,7 +73,7 @@
 (defun quil-indent-line-function ()
   (if (or (save-excursion
             ;; The previous line is a DEFGATE or DEFCIRCUIT
-	    (forward-line -1)
+            (forward-line -1)
             (re-search-forward (rx (or "DEFGATE" "DEFCIRCUIT")
                                    (1+ (or space ?\( ?\) ?# ?_ word)) ?:)
                                (line-end-position) t))
@@ -81,7 +81,7 @@
             ;; Previous line is indent to column four
             (forward-line -1)
             (quil-beginning-of-line-text-or-comment-start)
-	    (/= 0 (current-column))))
+            (/= 0 (current-column))))
       (indent-line-to 4)))
 
 ;;;###autoload

--- a/test.quil
+++ b/test.quil
@@ -1,4 +1,9 @@
+# This is an example Quil file for testing quil-mode.
+# Check out the amazing multi-line comment indentation.
+
 DEFGATE TESTGATE(%theta) A B:
+    # You can have comments here, too.
+    # Multi-line ones? Sure, why not.
     0, i,
     1, COS(-i*%theta)
 


### PR DESCRIPTION
Pressing RETURN at the end of a comment line now only indents the next line if the previous comment was also indented.

Please delay merging until feeling wonderbar. No rush.